### PR TITLE
urlSlice can handle urls with both query params and hash strings

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -73,18 +73,13 @@ exports.urlSlice = function (url) {
     };
     for (var i = 0, len = url.length; i < len; i++) {
         if ( url[i] === '?' ) {
-            // find index of fragment identifier after query params identifier
             var fragmentIndex = url.indexOf('#', i + 1);
-            // if there is no fragment index
             if (fragmentIndex < 0) {
-                // substring will be the remaing length of the string
                 fragmentIndex = len;
             } else {
-                // seperate the hash string after the fragment identifier
                 result.hashStr = url.substring(fragmentIndex + 1);
             }
             result.url = url.substring(0, i);
-            // create substring up to the fragment identifier or to the end of the string
             result.queryStr = url.substring(i + 1, fragmentIndex);
             break;
         } else if (url[i] === '#') {

--- a/src/util.js
+++ b/src/util.js
@@ -72,7 +72,7 @@ exports.urlSlice = function (url) {
         url : url
     };
     for (var i = 0, len = url.length; i < len; i++) {
-        if ( url[i] === '?' ) {
+        if ( url[i] === '?' || url[i] === ';') {
             var fragmentIndex = url.indexOf('#', i + 1);
             if (fragmentIndex < 0) {
                 fragmentIndex = len;
@@ -86,11 +86,7 @@ exports.urlSlice = function (url) {
             result.url = url.substring(0, i)
             result.hashStr = url.substring(i + 1);
             break;
-        } else if (url[i] === ';') {
-            result.url = url.substring(0, i)
-            result.queryStr = url.substring(i + 1);
-            break;
-        }
+        } 
     }
     return result;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -66,24 +66,37 @@ exports.getAllRegexMatches = function (string, regex) {
     if (index > 0) return url.substr(0, index);
     return url;
 } */
+
+/* 
+\this\is\sample?q1=val&q2=val3
+\this\is\sample#q1=val&q2=val3
+\this\is\sample?q1=val&q2=val3#q1=val&q2=val3
+\this\is\sample?q1=val&q2=val3#q1=val#q2=val3 //# => q1=val#q2=val3
+*/
 exports.urlSlice = function (url) {
     var result = {
         url : url
     };
     for (var i = 0, len = url.length; i < len; i++) {
-        if( url[i] === '?' ) {
-            result.url = url.substr(0, i)
-            result.queryStr = url.substr(i+1);
+        if ( url[i] === '?' ) {
+            var fragmentIndex = url.indexOf('#', i+1);
+            if (fragmentIndex > i) {
+                result.hashStr = url.substr(fragmentIndex + 1);
+            } else {
+                fragmentIndex = url.length;
+            }
+            result.url = url.substr(0, i);
+            result.queryStr = url.substr(i + 1, fragmentIndex);
             break;
-        }else if( url[i] === '#' ) {
+        } else if (url[i] === '#') {
             result.url = url.substr(0, i)
             result.hashStr = url.substr(i+1);
             break;
-        }else if( url[i] === ';' ) {
+        } else if (url[i] === ';') {
             result.url = url.substr(0, i)
-            result.queryStr = url.substr(i+1);
+            result.queryStr = url.substr(i + 1);
             break;
         }
-      }
+    }
     return result;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -73,9 +73,9 @@ exports.urlSlice = function (url) {
     };
     for (var i = 0, len = url.length; i < len; i++) {
         if ( url[i] === '?' ) {
-            var fragmentIndex = url.indexOf('#', i+1);
-            if (fragmentIndex < 0) {
-                fragmentIndex = url.length;
+            var fragmentIndex = url.indexOf('#', i + 1);
+            if (fragmentIndex < i) {
+                fragmentIndex = len;
             } else {
                 result.hashStr = url.substring(fragmentIndex + 1);
             }
@@ -84,7 +84,7 @@ exports.urlSlice = function (url) {
             break;
         } else if (url[i] === '#') {
             result.url = url.substring(0, i)
-            result.hashStr = url.substring(i+1);
+            result.hashStr = url.substring(i + 1);
             break;
         } else if (url[i] === ';') {
             result.url = url.substring(0, i)

--- a/src/util.js
+++ b/src/util.js
@@ -67,12 +67,6 @@ exports.getAllRegexMatches = function (string, regex) {
     return url;
 } */
 
-/* 
-\this\is\sample?q1=val&q2=val3
-\this\is\sample#q1=val&q2=val3
-\this\is\sample?q1=val&q2=val3#q1=val&q2=val3
-\this\is\sample?q1=val&q2=val3#q1=val#q2=val3 //# => q1=val#q2=val3
-*/
 exports.urlSlice = function (url) {
     var result = {
         url : url
@@ -80,23 +74,25 @@ exports.urlSlice = function (url) {
     for (var i = 0, len = url.length; i < len; i++) {
         if ( url[i] === '?' ) {
             var fragmentIndex = url.indexOf('#', i+1);
-            if (fragmentIndex > i) {
-                result.hashStr = url.substr(fragmentIndex + 1);
-            } else {
+            if (fragmentIndex < 0) {
                 fragmentIndex = url.length;
+            } else {
+                result.hashStr = url.substring(fragmentIndex + 1);
             }
-            result.url = url.substr(0, i);
-            result.queryStr = url.substr(i + 1, fragmentIndex);
+            result.url = url.substring(0, i);
+            result.queryStr = url.substring(i + 1, fragmentIndex);
             break;
         } else if (url[i] === '#') {
-            result.url = url.substr(0, i)
-            result.hashStr = url.substr(i+1);
+            result.url = url.substring(0, i)
+            result.hashStr = url.substring(i+1);
             break;
         } else if (url[i] === ';') {
-            result.url = url.substr(0, i)
-            result.queryStr = url.substr(i + 1);
+            result.url = url.substring(0, i)
+            result.queryStr = url.substring(i + 1);
             break;
         }
     }
     return result;
 }
+
+exports.urlSlice("/this/is/sample?q1=val&q2=val3#q2=val2&q3=val4");

--- a/src/util.js
+++ b/src/util.js
@@ -73,13 +73,18 @@ exports.urlSlice = function (url) {
     };
     for (var i = 0, len = url.length; i < len; i++) {
         if ( url[i] === '?' ) {
+            // find index of fragment identifier after query params identifier
             var fragmentIndex = url.indexOf('#', i + 1);
-            if (fragmentIndex < i) {
+            // if there is no fragment index
+            if (fragmentIndex < 0) {
+                // substring will be the remaing length of the string
                 fragmentIndex = len;
             } else {
+                // seperate the hash string after the fragment identifier
                 result.hashStr = url.substring(fragmentIndex + 1);
             }
             result.url = url.substring(0, i);
+            // create substring up to the fragment identifier or to the end of the string
             result.queryStr = url.substring(i + 1, fragmentIndex);
             break;
         } else if (url[i] === '#') {

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -2,13 +2,6 @@ var util = require('../src/util');
 
 describe("urlSlice", function() {
     var { urlSlice } = util;
-
-    it("should seperate url path from query params and fragment", function() {
-
-        var result = urlSlice("/this/is/sample?q1=val&q2=val3")
-        expect(result.url).toEqual("/this/is/sample");
-
-    });
   
     it("should handle urls with query string", function() {
 
@@ -41,5 +34,18 @@ describe("urlSlice", function() {
         expect(result.hashStr).toEqual("q1=val#q2=val3");
         
     });
+    
+    it("should only slice the query string after the first query params identifier if there are multiple", function() {
 
+        var result = urlSlice("/this/is/sample?q1=val&q2=val3?q1=val#q2=val3");
+        expect(result.queryStr).toEqual("q1=val&q2=val3?q1=val");
+        
+    });
+
+    it("should slice the hash string correctly if a query params identifier appears in the fragment string", function() {
+
+        var result = urlSlice("/this/is/sample#q1=val&q2=val3&q1=val?q2=val3");
+        expect(result.hashStr).toEqual("q1=val&q2=val3&q1=val?q2=val3");
+        
+    });
 });

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -1,14 +1,7 @@
 var util = require('../src/util');
 
-/* 
-/this/is/sample?q1=val&q2=val3
-/this/is/sample#q1=val&q2=val3
-/this/is/sample?q1=val&q2=val3#q1=val&q2=val3
-/this/is/sample?q1=val&q2=val3#q1=val#q2=val3 //# => q1=val#q2=val3
-*/
-
 describe("urlSlice", function() {
-    var urlSlice = util.urlSlice;
+    var { urlSlice } = util;
 
     it("should seperate url path from query params and fragment", function() {
 
@@ -39,7 +32,14 @@ describe("urlSlice", function() {
         expect(result.url).toEqual("/this/is/sample");
         expect(result.queryStr).toEqual("q1=val&q2=val3");
         expect(result.hashStr).toEqual("q2=val2&q3=val4");
+
+    });
+
+    it("should only slice the hash string after the first fragment identifier if there are multiple", function() {
+
+        var result = urlSlice("/this/is/sample?q1=val&q2=val3#q1=val#q2=val3");
+        expect(result.hashStr).toEqual("q1=val#q2=val3");
         
-    })
+    });
 
 });

--- a/tests/util_test.js
+++ b/tests/util_test.js
@@ -1,0 +1,45 @@
+var util = require('../src/util');
+
+/* 
+/this/is/sample?q1=val&q2=val3
+/this/is/sample#q1=val&q2=val3
+/this/is/sample?q1=val&q2=val3#q1=val&q2=val3
+/this/is/sample?q1=val&q2=val3#q1=val#q2=val3 //# => q1=val#q2=val3
+*/
+
+describe("urlSlice", function() {
+    var urlSlice = util.urlSlice;
+
+    it("should seperate url path from query params and fragment", function() {
+
+        var result = urlSlice("/this/is/sample?q1=val&q2=val3")
+        expect(result.url).toEqual("/this/is/sample");
+
+    });
+  
+    it("should handle urls with query string", function() {
+
+        var result = urlSlice("/this/is/sample?q1=val&q2=val3");
+        expect(result.url).toEqual("/this/is/sample");
+        expect(result.queryStr).toEqual("q1=val&q2=val3");
+
+    });
+
+    it("should handle urls with hash", function() {
+
+        var result = urlSlice("/this/is/sample#q1=val&q2=val3");
+        expect(result.url).toEqual("/this/is/sample");
+        expect(result.hashStr).toEqual("q1=val&q2=val3");
+      
+    });
+
+    it("should handle urls with both query string and hash", function() {
+      
+        var result = urlSlice("/this/is/sample?q1=val&q2=val3#q2=val2&q3=val4");
+        expect(result.url).toEqual("/this/is/sample");
+        expect(result.queryStr).toEqual("q1=val&q2=val3");
+        expect(result.hashStr).toEqual("q2=val2&q3=val4");
+        
+    })
+
+});


### PR DESCRIPTION
My idea for implementation is on finding a query params identifier we will search from the next index to the end of the string looking for a fragment identifier. If the index of the fragment Identifier is greater than the index of the params Identifier (I realize this is redundant now because we only search the substring after the params identifier, my initial implementation was to check if it was greater than 0 ie. we found it) then we will create a hashStr from the fragment identifier to the end of the string and create a queryStr from the index of the params identifier to the fragment Identifier. If the fragment Identifier is not found after the query params Identifier we set the fragment identifier to be the length of the string and create a substring from that. I have included tests for all of the cases that you showed me in your examples. The last thing I changed is I saw that .substr() has been deprecated in favor of .substring() which did not impact the implementation of the code I inherited. Thank you for allowing me to have a chance at my first open source contribution! Any feedback or review is welcome!