### PR TITLE
Issue 12 - Print the list of registered routes

### DIFF
--- a/src/letsRoute.js
+++ b/src/letsRoute.js
@@ -70,7 +70,8 @@ Anumargak.prototype.on = function (method, url, options, fn, extraData) {
         throw Error("Invalid method argument. String or array is expected.");
     }
     
-    listOfMethods[method]
+    // Save the list method, url and version to be printed
+    listOfMethods[method] = {};
     listOfRoutes.push({
             method: method,
             url: url,
@@ -612,13 +613,49 @@ function defaultRoute(req, res) {
 
 Anumargak.prototype.printRoutes = function(){
 
+   process.stdout.write("\nLIST OF Methods Used\n"+
+                           "--------------------\n\n");
 
-    Object.entries(listOfRoutes.methods).forEach(entry => {
-        var key = entry[0];
-        var value = entry[1];
-        console.log(key + "")
-        console.log(value)
-    })
+   console.log( Object.keys(listOfMethods))
+
+   process.stdout.write("\nLIST OF STATIC AND DYNAMIC ROUTES\n"+
+                          "---------------------------------\n\n");
+
+   // variable which we will print to the screen
+   var stringToPrint;
+   
+   // Iterate through each of the methods 
+   Object.keys(listOfMethods).forEach(function(key, index){
+
+       process.stdout.write(key + "\n { \n");
+
+       // Iterate through all of the objects which hold the route url's and versions 
+       for(var i=0; i < listOfRoutes.length; i++){
+           
+           // reset the string we use to print to the screen
+           stringToPrint = "";
+           
+           // We will print this object if its method matches the listOfMethods object 
+           if ( key == listOfRoutes [ i ] . method)
+           {
+               // start constructing the string which will be printed out
+               stringToPrint =  "     " + listOfRoutes [ i ] .url;
+             
+               // check to see if there is a version and if there is append it to the string
+              if ( listOfRoutes [i] .version)
+              {
+               stringToPrint += " { with version => " + listOfRoutes [i] .version + " }\n";
+              } else { 
+                  // no version, append a newline to the string
+                  stringToPrint += "\n" 
+               }
+               // print out route to screen
+               process.stdout.write(stringToPrint);
+           }
+       }
+       // newlines for the next method
+       process.stdout.write(" }\n\n");
+    });
 }
 
 module.exports = Anumargak;

--- a/src/letsRoute.js
+++ b/src/letsRoute.js
@@ -29,6 +29,10 @@ Anumargak.prototype._onEvent = function (eventName, fn) {
     this.eventEmitter.on(_name, fn);
 }
 
+// Object used to hold list of routes we can print for debugging
+var listOfRoutes = [];
+var listOfMethods = {};
+
 /**
  * Adds routes against the given method and URL
  * @param {string | array} method 
@@ -66,6 +70,13 @@ Anumargak.prototype.on = function (method, url, options, fn, extraData) {
         throw Error("Invalid method argument. String or array is expected.");
     }
     
+    listOfMethods[method]
+    listOfRoutes.push({
+            method: method,
+            url: url,
+            version: options.version ? options.version : ""
+        })
+
     return this;
 }
 
@@ -598,4 +609,16 @@ function defaultRoute(req, res) {
     res.statusCode = 404
     res.end()
 }
+
+Anumargak.prototype.printRoutes = function(){
+
+
+    Object.entries(listOfRoutes.methods).forEach(entry => {
+        var key = entry[0];
+        var value = entry[1];
+        console.log(key + "")
+        console.log(value)
+    })
+}
+
 module.exports = Anumargak;


### PR DESCRIPTION
Added method to print list of all registered routes with versions included.

Output is as follows:

**LIST OF STATIC AND DYNAMIC ROUTES
---------------------------------

GET
 {
     /home/:b
     /this/is/:dynamic/with/:two(\d+):params
     /login/as/:role(admin|user|staff)
     /this/is/:dynamic/and/*
     /some/route { with version => 1.2.0 }
     /some/route { with version => 1.2.3 }
     /this/is/static
     /this/is/static { with version => 1.2.0 }
     /this/is/:dynamic
 }

POST
 {
     /
     /home/:A
     /this/is/:dynamic
 }**